### PR TITLE
changed guid check from regex to tryparse

### DIFF
--- a/LoginRadius.cs
+++ b/LoginRadius.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Net;
-using System.Text.RegularExpressions;
 using System.Web;
 using LoginRadiusDataModal.LoginRadiusDataObject.Factory;
 using LoginRadiusDataModal.LoginRadiusDataObject.Objects;
@@ -105,12 +104,8 @@ namespace LoginRadiusSDK {
         /// <param name="candidate">string to validate</param>
         /// <returns>boolean</returns>
         private static bool IsGuid(string candidate) {
-            try {
-                Regex guid = new Regex(@"^(\{){0,1}[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}(\}){0,1}$", RegexOptions.Compiled);
-                if (candidate != null && guid.IsMatch(candidate)) return true;
-            }
-            catch (Exception) { throw; }
-            return false;
+            Guid output;
+            return Guid.TryParse(candidate, out output);
         }
     }
 }


### PR DESCRIPTION
Changed the Guid checking from the use of a regular expression to Guid.TryPrase. It just seems a lot safer using Guid.TryParse which by default handles both scenarios the regular expression was handling

http://msdn.microsoft.com/en-us/library/system.guid.tryparse.aspx

//    Converted {81a130d2-502f-4cf1-a376-63edeb000e9f} to a Guid 
//    Converted 81a130d2-502f-4cf1-a376-63edeb000e9f to a Guid 
