### PR TITLE
Silence documentation warnings

### DIFF
--- a/Source/LoginRadiusSDK.V2/Api/Account/AccountApi.cs
+++ b/Source/LoginRadiusSDK.V2/Api/Account/AccountApi.cs
@@ -20,7 +20,7 @@ namespace LoginRadiusSDK.V2.Api.Account
         /// <summary>
         /// This API is used to update the information of existing accounts in your Cloud Storage. See our Advanced API Usage section <a href='https://www.loginradius.com/docs/api/v2/customer-identity-api/advanced-api-usage'>Here</a> for more capabilities.
         /// </summary>
-        /// <param name="accountUserProfileUpdateModel">Model Class containing Definition of payload for Account Update API</param>
+        /// <param name="payload">Model Class containing Definition of payload for Account Update API</param>
         /// <param name="uid">UID, the unified identifier for each user account</param>
         /// <param name="fields">The fields parameter filters the API response so that the response only includes a specific set of fields</param>
         /// <param name="nullSupport">Boolean, pass true if you wish to update any user profile field with a NULL value, You can get the details <a href='https://www.loginradius.com/docs/api/v2/customer-identity-api/advanced-api-usage#nullsupport0'>Here</a></param>
@@ -81,7 +81,7 @@ namespace LoginRadiusSDK.V2.Api.Account
             return ConfigureAndExecute<PrivacyPolicyHistoryResponse>(HttpMethod.GET, resourcePath, queryParameters, null);
         }
         /// <summary>
-        /// This API is used to create an account in Cloud Storage. This API bypass the normal email verification process and manually creates the user. <br><br>In order to use this API, you need to format a JSON request body with all of the mandatory fields
+        /// This API is used to create an account in Cloud Storage. This API bypass the normal email verification process and manually creates the user. <br/><br/>In order to use this API, you need to format a JSON request body with all of the mandatory fields
         /// </summary>
         /// <param name="accountCreateModel">Model Class containing Definition of payload for Account Create API</param>
         /// <param name="fields">The fields parameter filters the API response so that the response only includes a specific set of fields</param>

--- a/Source/LoginRadiusSDK.V2/Api/Advanced/ConsentManagementApi.cs
+++ b/Source/LoginRadiusSDK.V2/Api/Advanced/ConsentManagementApi.cs
@@ -122,7 +122,7 @@ namespace LoginRadiusSDK.V2.Api.Advanced
         /// This API is used to check if consent is submitted for a particular event or not.
         /// </summary>
         /// <param name="accessToken">Uniquely generated identifier key by LoginRadius that is activated after successful authentication.</param>
-        /// <param name="@event">Allowed events: Login, Register, UpdateProfile, ResetPassword, ChangePassword, emailVerification, AddEmail, RemoveEmail, BlockAccount, DeleteAccount, SetUsername, AssignRoles, UnassignRoles, SetPassword, LinkAccount, UnlinkAccount, UpdatePhoneId, VerifyPhoneNumber, CreateCustomObject, UpdateCustomobject, DeleteCustomObject</param>
+        /// <param name="event">Allowed events: Login, Register, UpdateProfile, ResetPassword, ChangePassword, emailVerification, AddEmail, RemoveEmail, BlockAccount, DeleteAccount, SetUsername, AssignRoles, UnassignRoles, SetPassword, LinkAccount, UnlinkAccount, UpdatePhoneId, VerifyPhoneNumber, CreateCustomObject, UpdateCustomobject, DeleteCustomObject</param>
         /// <param name="isCustom">true/false</param>
         /// <returns>Response containing consent profile</returns>
         /// 43.4

--- a/Source/LoginRadiusSDK.V2/Api/Advanced/WebHookApi.cs
+++ b/Source/LoginRadiusSDK.V2/Api/Advanced/WebHookApi.cs
@@ -18,7 +18,7 @@ namespace LoginRadiusSDK.V2.Api.Advanced
         /// <summary>
         /// This API is used to fatch all the subscribed URLs, for particular event
         /// </summary>
-        /// <param name="@event">Allowed events: Login, Register, UpdateProfile, ResetPassword, ChangePassword, emailVerification, AddEmail, RemoveEmail, BlockAccount, DeleteAccount, SetUsername, AssignRoles, UnassignRoles, SetPassword, LinkAccount, UnlinkAccount, UpdatePhoneId, VerifyPhoneNumber, CreateCustomObject, UpdateCustomobject, DeleteCustomObject</param>
+        /// <param name="event">Allowed events: Login, Register, UpdateProfile, ResetPassword, ChangePassword, emailVerification, AddEmail, RemoveEmail, BlockAccount, DeleteAccount, SetUsername, AssignRoles, UnassignRoles, SetPassword, LinkAccount, UnlinkAccount, UpdatePhoneId, VerifyPhoneNumber, CreateCustomObject, UpdateCustomobject, DeleteCustomObject</param>
         /// <returns>Response Containing List of Webhhook Data</returns>
         /// 40.1
 

--- a/Source/LoginRadiusSDK.V2/Api/Authentication/AuthenticationApi.cs
+++ b/Source/LoginRadiusSDK.V2/Api/Authentication/AuthenticationApi.cs
@@ -22,7 +22,7 @@ namespace LoginRadiusSDK.V2.Api.Authentication
         /// This API is used to update the user's profile by passing the access_token.
         /// </summary>
         /// <param name="accessToken">Uniquely generated identifier key by LoginRadius that is activated after successful authentication.</param>
-        /// <param name="userProfileUpdateModel">Model Class containing Definition of payload for User Profile update API</param>
+        /// <param name="payload">Model Class containing Definition of payload for User Profile update API</param>
         /// <param name="emailTemplate">Email template name</param>
         /// <param name="fields">The fields parameter filters the API response so that the response only includes a specific set of fields</param>
         /// <param name="nullSupport">>Boolean, pass true if you wish to update any user profile field with a NULL value, You can get the details <a href='https://www.loginradius.com/docs/api/v2/customer-identity-api/advanced-api-usage#nullsupport0'>Here</a></param>

--- a/Source/LoginRadiusSDK.V2/Api/Social/SocialApi.cs
+++ b/Source/LoginRadiusSDK.V2/Api/Social/SocialApi.cs
@@ -42,7 +42,7 @@ namespace LoginRadiusSDK.V2.Api.Social
             return ConfigureAndExecute<AccessToken>(HttpMethod.GET, resourcePath, queryParameters, null);
         }
         /// <summary>
-        /// The Refresh Access Token API is used to refresh the provider access token after authentication. It will be valid for up to 60 days on LoginRadius depending on the provider. In order to use the access token in other APIs, always refresh the token using this API.<br><br><b>Supported Providers :</b> Facebook,Yahoo,Google,Twitter, Linkedin.<br><br> Contact LoginRadius support team to enable this API.
+        /// The Refresh Access Token API is used to refresh the provider access token after authentication. It will be valid for up to 60 days on LoginRadius depending on the provider. In order to use the access token in other APIs, always refresh the token using this API.<br/><br/><b>Supported Providers :</b> Facebook,Yahoo,Google,Twitter, Linkedin.<br/><br/> Contact LoginRadius support team to enable this API.
         /// </summary>
         /// <param name="accessToken">Uniquely generated identifier key by LoginRadius that is activated after successful authentication.</param>
         /// <param name="expiresIn">Allows you to specify a desired expiration time in minutes for the newly issued access_token.</param>
@@ -190,7 +190,7 @@ namespace LoginRadiusSDK.V2.Api.Social
             return ConfigureAndExecute<UserActiveSession>(HttpMethod.GET, resourcePath, queryParameters, null);
         }
         /// <summary>
-        /// <b>Supported Providers:</b> Facebook, Google, Live, Vkontakte.<br><br> This API returns the photo albums associated with the passed in access tokens Social Profile.
+        /// <b>Supported Providers:</b> Facebook, Google, Live, Vkontakte.<br/><br/> This API returns the photo albums associated with the passed in access tokens Social Profile.
         /// </summary>
         /// <param name="accessToken">Uniquely generated identifier key by LoginRadius that is activated after successful authentication.</param>
         /// <returns>Response Containing List of Album Data</returns>
@@ -212,7 +212,7 @@ namespace LoginRadiusSDK.V2.Api.Social
             return ConfigureAndExecute<List<Album>>(HttpMethod.GET, resourcePath, queryParameters, null);
         }
         /// <summary>
-        /// <b>Supported Providers:</b> Facebook, Google, Live, Vkontakte.<br><br> This API returns the photo albums associated with the passed in access tokens Social Profile.
+        /// <b>Supported Providers:</b> Facebook, Google, Live, Vkontakte.<br/><br/> This API returns the photo albums associated with the passed in access tokens Social Profile.
         /// </summary>
         /// <param name="accessToken">Uniquely generated identifier key by LoginRadius that is activated after successful authentication.</param>
         /// <param name="nextCursor">Cursor value if not all contacts can be retrieved once.</param>
@@ -240,7 +240,7 @@ namespace LoginRadiusSDK.V2.Api.Social
             return ConfigureAndExecute<CursorResponse<Album>>(HttpMethod.GET, resourcePath, queryParameters, null);
         }
         /// <summary>
-        /// The Audio API is used to get audio files data from the user's social account.<br><br><b>Supported Providers:</b> Live, Vkontakte
+        /// The Audio API is used to get audio files data from the user's social account.<br/><br/><b>Supported Providers:</b> Live, Vkontakte
         /// </summary>
         /// <param name="accessToken">Uniquely generated identifier key by LoginRadius that is activated after successful authentication.</param>
         /// <returns>Response Containing List of Audio Data</returns>
@@ -262,7 +262,7 @@ namespace LoginRadiusSDK.V2.Api.Social
             return ConfigureAndExecute<List<Audio>>(HttpMethod.GET, resourcePath, queryParameters, null);
         }
         /// <summary>
-        /// The Audio API is used to get audio files data from the user's social account.<br><br><b>Supported Providers:</b> Live, Vkontakte
+        /// The Audio API is used to get audio files data from the user's social account.<br/><br/><b>Supported Providers:</b> Live, Vkontakte
         /// </summary>
         /// <param name="accessToken">Uniquely generated identifier key by LoginRadius that is activated after successful authentication.</param>
         /// <param name="nextCursor">Cursor value if not all contacts can be retrieved once.</param>
@@ -290,7 +290,7 @@ namespace LoginRadiusSDK.V2.Api.Social
             return ConfigureAndExecute<CursorResponse<Audio>>(HttpMethod.GET, resourcePath, queryParameters, null);
         }
         /// <summary>
-        /// The Check In API is used to get check Ins data from the user's social account.<br><br><b>Supported Providers:</b> Facebook, Foursquare, Vkontakte
+        /// The Check In API is used to get check Ins data from the user's social account.<br/><br/><b>Supported Providers:</b> Facebook, Foursquare, Vkontakte
         /// </summary>
         /// <param name="accessToken">Uniquely generated identifier key by LoginRadius that is activated after successful authentication.</param>
         /// <returns>Response Containing List of CheckIn Data</returns>
@@ -312,7 +312,7 @@ namespace LoginRadiusSDK.V2.Api.Social
             return ConfigureAndExecute<List<CheckIn>>(HttpMethod.GET, resourcePath, queryParameters, null);
         }
         /// <summary>
-        /// The Check In API is used to get check Ins data from the user's social account.<br><br><b>Supported Providers:</b> Facebook, Foursquare, Vkontakte
+        /// The Check In API is used to get check Ins data from the user's social account.<br/><br/><b>Supported Providers:</b> Facebook, Foursquare, Vkontakte
         /// </summary>
         /// <param name="accessToken">Uniquely generated identifier key by LoginRadius that is activated after successful authentication.</param>
         /// <param name="nextCursor">Cursor value if not all contacts can be retrieved once.</param>
@@ -340,7 +340,7 @@ namespace LoginRadiusSDK.V2.Api.Social
             return ConfigureAndExecute<CursorResponse<CheckIn>>(HttpMethod.GET, resourcePath, queryParameters, null);
         }
         /// <summary>
-        /// The Contact API is used to get contacts/friends/connections data from the user's social account.This is one of the APIs that makes up the LoginRadius Friend Invite System. The data will normalized into LoginRadius' standard data format. This API requires setting permissions in your LoginRadius Dashboard. <br><br><b>Note:</b> Facebook restricts access to the list of friends that is returned. When using the Contacts API with Facebook you will only receive friends that have accepted some permissions with your app. <br><br><b>Supported Providers:</b> Facebook, Foursquare, Google, LinkedIn, Live, Twitter, Vkontakte, Yahoo
+        /// The Contact API is used to get contacts/friends/connections data from the user's social account.This is one of the APIs that makes up the LoginRadius Friend Invite System. The data will normalized into LoginRadius' standard data format. This API requires setting permissions in your LoginRadius Dashboard. <br/><br/><b>Note:</b> Facebook restricts access to the list of friends that is returned. When using the Contacts API with Facebook you will only receive friends that have accepted some permissions with your app. <br/><br/><b>Supported Providers:</b> Facebook, Foursquare, Google, LinkedIn, Live, Twitter, Vkontakte, Yahoo
         /// </summary>
         /// <param name="accessToken">Uniquely generated identifier key by LoginRadius that is activated after successful authentication.</param>
         /// <param name="nextCursor">Cursor value if not all contacts can be retrieved once.</param>
@@ -367,7 +367,7 @@ namespace LoginRadiusSDK.V2.Api.Social
             return ConfigureAndExecute<CursorResponse<Contact>>(HttpMethod.GET, resourcePath, queryParameters, null);
         }
         /// <summary>
-        /// The Event API is used to get the event data from the user's social account.<br><br><b>Supported Providers:</b> Facebook, Live
+        /// The Event API is used to get the event data from the user's social account.<br/><br/><b>Supported Providers:</b> Facebook, Live
         /// </summary>
         /// <param name="accessToken">Uniquely generated identifier key by LoginRadius that is activated after successful authentication.</param>
         /// <returns>Response Containing List of Events Data</returns>
@@ -389,7 +389,7 @@ namespace LoginRadiusSDK.V2.Api.Social
             return ConfigureAndExecute<List<Events>>(HttpMethod.GET, resourcePath, queryParameters, null);
         }
         /// <summary>
-        /// The Event API is used to get the event data from the user's social account.<br><br><b>Supported Providers:</b> Facebook, Live
+        /// The Event API is used to get the event data from the user's social account.<br/><br/><b>Supported Providers:</b> Facebook, Live
         /// </summary>
         /// <param name="accessToken">Uniquely generated identifier key by LoginRadius that is activated after successful authentication.</param>
         /// <param name="nextCursor">Cursor value if not all contacts can be retrieved once.</param>
@@ -417,7 +417,7 @@ namespace LoginRadiusSDK.V2.Api.Social
             return ConfigureAndExecute<CursorResponse<Events>>(HttpMethod.GET, resourcePath, queryParameters, null);
         }
         /// <summary>
-        /// Get the following user list from the user's social account.<br><br><b>Supported Providers:</b> Twitter
+        /// Get the following user list from the user's social account.<br/><br/><b>Supported Providers:</b> Twitter
         /// </summary>
         /// <param name="accessToken">Uniquely generated identifier key by LoginRadius that is activated after successful authentication.</param>
         /// <returns>Response Containing List of Contacts Data</returns>
@@ -439,7 +439,7 @@ namespace LoginRadiusSDK.V2.Api.Social
             return ConfigureAndExecute<List<Contact>>(HttpMethod.GET, resourcePath, queryParameters, null);
         }
         /// <summary>
-        /// Get the following user list from the user's social account.<br><br><b>Supported Providers:</b> Twitter
+        /// Get the following user list from the user's social account.<br/><br/><b>Supported Providers:</b> Twitter
         /// </summary>
         /// <param name="accessToken">Uniquely generated identifier key by LoginRadius that is activated after successful authentication.</param>
         /// <param name="nextCursor">Cursor value if not all contacts can be retrieved once.</param>
@@ -467,7 +467,7 @@ namespace LoginRadiusSDK.V2.Api.Social
             return ConfigureAndExecute<CursorResponse<Contact>>(HttpMethod.GET, resourcePath, queryParameters, null);
         }
         /// <summary>
-        /// The Group API is used to get group data from the user's social account.<br><br><b>Supported Providers:</b> Facebook, Vkontakte
+        /// The Group API is used to get group data from the user's social account.<br/><br/><b>Supported Providers:</b> Facebook, Vkontakte
         /// </summary>
         /// <param name="accessToken">Uniquely generated identifier key by LoginRadius that is activated after successful authentication.</param>
         /// <returns>Response Containing List of Groups Data</returns>
@@ -489,7 +489,7 @@ namespace LoginRadiusSDK.V2.Api.Social
             return ConfigureAndExecute<List<Group>>(HttpMethod.GET, resourcePath, queryParameters, null);
         }
         /// <summary>
-        /// The Group API is used to get group data from the user's social account.<br><br><b>Supported Providers:</b> Facebook, Vkontakte
+        /// The Group API is used to get group data from the user's social account.<br/><br/><b>Supported Providers:</b> Facebook, Vkontakte
         /// </summary>
         /// <param name="accessToken">Uniquely generated identifier key by LoginRadius that is activated after successful authentication.</param>
         /// <param name="nextCursor">Cursor value if not all contacts can be retrieved once.</param>
@@ -517,7 +517,7 @@ namespace LoginRadiusSDK.V2.Api.Social
             return ConfigureAndExecute<CursorResponse<Group>>(HttpMethod.GET, resourcePath, queryParameters, null);
         }
         /// <summary>
-        /// The Like API is used to get likes data from the user's social account.<br><br><b>Supported Providers:</b> Facebook
+        /// The Like API is used to get likes data from the user's social account.<br/><br/><b>Supported Providers:</b> Facebook
         /// </summary>
         /// <param name="accessToken">Uniquely generated identifier key by LoginRadius that is activated after successful authentication.</param>
         /// <returns>Response Containing List of Likes Data</returns>
@@ -539,7 +539,7 @@ namespace LoginRadiusSDK.V2.Api.Social
             return ConfigureAndExecute<List<Like>>(HttpMethod.GET, resourcePath, queryParameters, null);
         }
         /// <summary>
-        /// The Like API is used to get likes data from the user's social account.<br><br><b>Supported Providers:</b> Facebook
+        /// The Like API is used to get likes data from the user's social account.<br/><br/><b>Supported Providers:</b> Facebook
         /// </summary>
         /// <param name="accessToken">Uniquely generated identifier key by LoginRadius that is activated after successful authentication.</param>
         /// <param name="nextCursor">Cursor value if not all contacts can be retrieved once.</param>
@@ -567,7 +567,7 @@ namespace LoginRadiusSDK.V2.Api.Social
             return ConfigureAndExecute<CursorResponse<Like>>(HttpMethod.GET, resourcePath, queryParameters, null);
         }
         /// <summary>
-        /// The Mention API is used to get mentions data from the user's social account.<br><br><b>Supported Providers:</b> Twitter
+        /// The Mention API is used to get mentions data from the user's social account.<br/><br/><b>Supported Providers:</b> Twitter
         /// </summary>
         /// <param name="accessToken">Uniquely generated identifier key by LoginRadius that is activated after successful authentication.</param>
         /// <returns>Response Containing List of Status Data</returns>
@@ -589,7 +589,7 @@ namespace LoginRadiusSDK.V2.Api.Social
             return ConfigureAndExecute<List<Status>>(HttpMethod.GET, resourcePath, queryParameters, null);
         }
         /// <summary>
-        /// Post Message API is used to post messages to the user's contacts.<br><br><b>Supported Providers:</b> Twitter, LinkedIn <br><br>The Message API is used to post messages to the user?s contacts. This is one of the APIs that makes up the LoginRadius Friend Invite System. After using the Contact API, you can send messages to the retrieved contacts. This API requires setting permissions in your LoginRadius Dashboard.<br><br>GET & POST Message API work the same way except the API method is different
+        /// Post Message API is used to post messages to the user's contacts.<br/><br/><b>Supported Providers:</b> Twitter, LinkedIn <br/><br/>The Message API is used to post messages to the user's contacts. This is one of the APIs that makes up the LoginRadius Friend Invite System. After using the Contact API, you can send messages to the retrieved contacts. This API requires setting permissions in your LoginRadius Dashboard.<br/><br/>GET &amp; POST Message API work the same way except the API method is different
         /// </summary>
         /// <param name="accessToken">Uniquely generated identifier key by LoginRadius that is activated after successful authentication.</param>
         /// <param name="message">Body of your message</param>
@@ -630,7 +630,7 @@ namespace LoginRadiusSDK.V2.Api.Social
             return ConfigureAndExecute<PostMethodResponse>(HttpMethod.POST, resourcePath, queryParameters, null);
         }
         /// <summary>
-        /// The Page API is used to get the page data from the user's social account.<br><br><b>Supported Providers:</b>  Facebook, LinkedIn
+        /// The Page API is used to get the page data from the user's social account.<br/><br/><b>Supported Providers:</b>  Facebook, LinkedIn
         /// </summary>
         /// <param name="accessToken">Uniquely generated identifier key by LoginRadius that is activated after successful authentication.</param>
         /// <param name="pageName">Name of the page you want to retrieve info from</param>
@@ -658,7 +658,7 @@ namespace LoginRadiusSDK.V2.Api.Social
             return ConfigureAndExecute<Page>(HttpMethod.GET, resourcePath, queryParameters, null);
         }
         /// <summary>
-        /// The Photo API is used to get photo data from the user's social account.<br><br><b>Supported Providers:</b>  Facebook, Foursquare, Google, Live, Vkontakte
+        /// The Photo API is used to get photo data from the user's social account.<br/><br/><b>Supported Providers:</b>  Facebook, Foursquare, Google, Live, Vkontakte
         /// </summary>
         /// <param name="accessToken">Uniquely generated identifier key by LoginRadius that is activated after successful authentication.</param>
         /// <param name="albumId">The id of the album you want to retrieve info from</param>
@@ -686,7 +686,7 @@ namespace LoginRadiusSDK.V2.Api.Social
             return ConfigureAndExecute<List<Photo>>(HttpMethod.GET, resourcePath, queryParameters, null);
         }
         /// <summary>
-        /// The Post API is used to get post message data from the user's social account.<br><br><b>Supported Providers:</b>  Facebook
+        /// The Post API is used to get post message data from the user's social account.<br/><br/><b>Supported Providers:</b>  Facebook
         /// </summary>
         /// <param name="accessToken">Uniquely generated identifier key by LoginRadius that is activated after successful authentication.</param>
         /// <returns>Response Containing List of Posts Data</returns>
@@ -708,7 +708,7 @@ namespace LoginRadiusSDK.V2.Api.Social
             return ConfigureAndExecute<List<Post>>(HttpMethod.GET, resourcePath, queryParameters, null);
         }
         /// <summary>
-        /// The Status API is used to update the status on the user's wall.<br><br><b>Supported Providers:</b>  Facebook, Twitter, LinkedIn
+        /// The Status API is used to update the status on the user's wall.<br/><br/><b>Supported Providers:</b>  Facebook, Twitter, LinkedIn
         /// </summary>
         /// <param name="accessToken">Uniquely generated identifier key by LoginRadius that is activated after successful authentication.</param>
         /// <param name="caption">Message displayed below the description(Requires URL, Under 70 Characters).</param>
@@ -773,7 +773,7 @@ namespace LoginRadiusSDK.V2.Api.Social
             return ConfigureAndExecute<PostMethodResponse<ShortUrlResponse>>(HttpMethod.POST, resourcePath, queryParameters, null);
         }
         /// <summary>
-        /// The Trackable status API works very similar to the Status API but it returns a Post id that you can use to track the stats(shares, likes, comments) for a specific share/post/status update. This API requires setting permissions in your LoginRadius Dashboard.<br><br> The Trackable Status API is used to update the status on the user's wall and return an Post ID value. It is commonly referred to as Permission based sharing or Push notifications.<br><br> POST Input Parameter Format: application/x-www-form-urlencoded
+        /// The Trackable status API works very similar to the Status API but it returns a Post id that you can use to track the stats(shares, likes, comments) for a specific share/post/status update. This API requires setting permissions in your LoginRadius Dashboard.<br/><br/> The Trackable Status API is used to update the status on the user's wall and return an Post ID value. It is commonly referred to as Permission based sharing or Push notifications.<br/><br/> POST Input Parameter Format: application/x-www-form-urlencoded
         /// </summary>
         /// <param name="accessToken">Uniquely generated identifier key by LoginRadius that is activated after successful authentication.</param>
         /// <param name="statusModel">Model Class containing Definition of payload for Status API</param>
@@ -800,7 +800,7 @@ namespace LoginRadiusSDK.V2.Api.Social
             return ConfigureAndExecute<StatusUpdateResponse>(HttpMethod.POST, resourcePath, queryParameters, ConvertToJson(statusModel));
         }
         /// <summary>
-        /// The Trackable status API works very similar to the Status API but it returns a Post id that you can use to track the stats(shares, likes, comments) for a specific share/post/status update. This API requires setting permissions in your LoginRadius Dashboard.<br><br> The Trackable Status API is used to update the status on the user's wall and return an Post ID value. It is commonly referred to as Permission based sharing or Push notifications.
+        /// The Trackable status API works very similar to the Status API but it returns a Post id that you can use to track the stats(shares, likes, comments) for a specific share/post/status update. This API requires setting permissions in your LoginRadius Dashboard.<br/><br/> The Trackable Status API is used to update the status on the user's wall and return an Post ID value. It is commonly referred to as Permission based sharing or Push notifications.
         /// </summary>
         /// <param name="accessToken">Uniquely generated identifier key by LoginRadius that is activated after successful authentication.</param>
         /// <param name="caption">Message displayed below the description(Requires URL, Under 70 Characters).</param>
@@ -859,7 +859,7 @@ namespace LoginRadiusSDK.V2.Api.Social
             return ConfigureAndExecute<StatusUpdateResponse>(HttpMethod.GET, resourcePath, queryParameters, null);
         }
         /// <summary>
-        /// The Trackable status API works very similar to the Status API but it returns a Post id that you can use to track the stats(shares, likes, comments) for a specific share/post/status update. This API requires setting permissions in your LoginRadius Dashboard.<br><br> This API is used to retrieve a tracked post based on the passed in post ID value. This API requires setting permissions in your LoginRadius Dashboard.<br><br> <b>Note:</b> To utilize this API you need to find the ID for the post you want to track, which might require using Trackable Status Posting API first.
+        /// The Trackable status API works very similar to the Status API but it returns a Post id that you can use to track the stats(shares, likes, comments) for a specific share/post/status update. This API requires setting permissions in your LoginRadius Dashboard.<br/><br/> This API is used to retrieve a tracked post based on the passed in post ID value. This API requires setting permissions in your LoginRadius Dashboard.<br/><br/> <b>Note:</b> To utilize this API you need to find the ID for the post you want to track, which might require using Trackable Status Posting API first.
         /// </summary>
         /// <param name="postId">Post ID value</param>
         /// <returns>Response containing Definition of Complete Status Update data</returns>
@@ -882,7 +882,7 @@ namespace LoginRadiusSDK.V2.Api.Social
             return ConfigureAndExecute<StatusUpdateStats>(HttpMethod.GET, resourcePath, queryParameters, null);
         }
         /// <summary>
-        /// The User Profile API is used to get social profile data from the user's social account after authentication.<br><br><b>Supported Providers:</b>  All
+        /// The User Profile API is used to get social profile data from the user's social account after authentication.<br/><br/><b>Supported Providers:</b>  All
         /// </summary>
         /// <param name="accessToken">Uniquely generated identifier key by LoginRadius that is activated after successful authentication.</param>
         /// <param name="fields">The fields parameter filters the API response so that the response only includes a specific set of fields</param>
@@ -936,7 +936,7 @@ namespace LoginRadiusSDK.V2.Api.Social
             return ConfigureAndExecute<UserProfile>(HttpMethod.GET, resourcePath, queryParameters, null);
         }
         /// <summary>
-        /// The Video API is used to get video files data from the user's social account.<br><br><b>Supported Providers:</b>   Facebook, Google, Live, Vkontakte
+        /// The Video API is used to get video files data from the user's social account.<br/><br/><b>Supported Providers:</b>   Facebook, Google, Live, Vkontakte
         /// </summary>
         /// <param name="accessToken">Uniquely generated identifier key by LoginRadius that is activated after successful authentication.</param>
         /// <param name="nextCursor">Cursor value if not all contacts can be retrieved once.</param>

--- a/Source/LoginRadiusSDK.V2/Common/LoginRadiusResource.cs
+++ b/Source/LoginRadiusSDK.V2/Common/LoginRadiusResource.cs
@@ -43,7 +43,6 @@ namespace LoginRadiusSDK.V2.Common
             DELETE
         }
 
-      
 
         /// <summary>
         /// Gets the last request sent by the SDK in the current thread.
@@ -55,7 +54,6 @@ namespace LoginRadiusSDK.V2.Common
         /// </summary>
         public static ThreadLocal<ResponseDetails> LastResponseDetails { get; private set; }
 
-       
 
         internal static ConcurrentDictionary<string, string> ConfigDictionary;
 
@@ -72,12 +70,11 @@ namespace LoginRadiusSDK.V2.Common
         /// <summary>
         /// Configures and executes REST call: Supports JSON
         /// </summary>
-        /// <param name="requestType"></param>
         /// <param name="httpMethod">HttpMethod type</param>
         /// <param name="resource">URI path of the resource</param>
         /// <param name="payload">JSON request payload</param>
         /// <param name="queryParameters"></param>
-        /// <returns>Response object or null otherwise for void API calls</returns>    
+        /// <returns>Response object or null otherwise for void API calls</returns>
         public static object ConfigureAndExecute(HttpMethod httpMethod, string resource,
             QueryParameters queryParameters, string payload = "")
         {
@@ -122,7 +119,6 @@ namespace LoginRadiusSDK.V2.Common
         /// 
         /// </summary>
         /// <typeparam name="T"></typeparam>
-        /// <param name="requestType"></param>
         /// <param name="httpMethod"></param>
         /// <param name="resource"></param>
         /// <returns></returns>
@@ -135,7 +131,6 @@ namespace LoginRadiusSDK.V2.Common
         /// 
         /// </summary>
         /// <typeparam name="T"></typeparam>
-        /// <param name="requestType"></param>
         /// <param name="httpMethod"></param>
         /// <param name="resource"></param>
         /// <param name="payload"></param>
@@ -149,7 +144,6 @@ namespace LoginRadiusSDK.V2.Common
         /// Configures and executes REST call: Supports JSON
         /// </summary>
         /// <typeparam name="T">Generic Type parameter for response object</typeparam>
-        /// <param name="requestType"></param>
         /// <param name="httpMethod">HttpMethod type</param>
         /// <param name="resource">URI path of the resource</param>
         /// <param name="payload">JSON request payload</param>
@@ -227,7 +221,6 @@ namespace LoginRadiusSDK.V2.Common
                 {
                     return (ApiResponse<T>)Convert.ChangeType(response, typeof(T));
                 }
-                
 
                 return new ApiResponse<T> { Response = JsonFormatter.ConvertFromJson<T>(response) };
             }
@@ -263,7 +256,6 @@ namespace LoginRadiusSDK.V2.Common
 
         private static string GetEndpoint(string apiPath, out Dictionary<string, string> authHeaders, QueryParameters additionalParameters = null)
         {
-           
             string baseEndPoint;
             authHeaders = null;
             if (ConfigDictionary.ContainsKey(LRConfigConstants.ApiRegion) && !string.IsNullOrWhiteSpace(ConfigDictionary[LRConfigConstants.ApiRegion])) {

--- a/Source/LoginRadiusSDK.V2/LoginRadiusSDK.V2.csproj
+++ b/Source/LoginRadiusSDK.V2/LoginRadiusSDK.V2.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard2.0;net45;net40</TargetFrameworks>
-    
     <Authors>LoginRadius Inc.</Authors>
     <RequireLicenseAcceptance>false</RequireLicenseAcceptance>
     <Language>en-US</Language>
@@ -45,12 +44,6 @@
     <IncludeSymbols>true</IncludeSymbols>
     <DefineConstants>RELEASE</DefineConstants>
   </PropertyGroup>
-
-  <ItemGroup>
-    <Compile Remove="Api\AdvancedSocial\**" />
-    <EmbeddedResource Remove="Api\AdvancedSocial\**" />
-    <None Remove="Api\AdvancedSocial\**" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />

--- a/Source/LoginRadiusSDK.V2/LoginRadiusSDK.V2.csproj
+++ b/Source/LoginRadiusSDK.V2/LoginRadiusSDK.V2.csproj
@@ -32,6 +32,7 @@
     <SignAssembly>true</SignAssembly>
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>LoginRadiusSDKV2.snk</AssemblyOriginatorKeyFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
@@ -39,8 +40,8 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <NoWarn>$(NoWarn);CS1591;CS1572;CS1573</NoWarn>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IncludeSymbols>true</IncludeSymbols>
     <DefineConstants>RELEASE</DefineConstants>
   </PropertyGroup>

--- a/Source/LoginRadiusSDK.V2/LoginRadiusSDK.V2.csproj
+++ b/Source/LoginRadiusSDK.V2/LoginRadiusSDK.V2.csproj
@@ -31,6 +31,7 @@
     <SignAssembly>true</SignAssembly>
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>LoginRadiusSDKV2.snk</AssemblyOriginatorKeyFile>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
@@ -39,7 +40,6 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IncludeSymbols>true</IncludeSymbols>
     <DefineConstants>RELEASE</DefineConstants>

--- a/Source/LoginRadiusSDK.V2/Util/SDKUtil.cs
+++ b/Source/LoginRadiusSDK.V2/Util/SDKUtil.cs
@@ -37,20 +37,13 @@ namespace LoginRadiusSDK.V2.Util
         }
 
         /// <summary>
-        /// Overload to above method to support LoginRadius path object class.
-        /// </summary>
-        /// <param name="pattern"></param>
-        /// <param name="parameters"></param>
-        /// <returns></returns>
-        
-
-        /// <summary>
         /// Formats the URI path for REST calls. Replaces any occurrences of the form
         /// {name} in pattern with the corresponding value of key name in the passed
         /// Dictionary
         /// </summary>
         /// <param name="pattern">URI pattern with named place holders</param>
         /// <param name="pathParameters">Dictionary</param>
+        /// <remarks>Overload to above method to support LoginRadius path object class.</remarks>
         /// <returns>Processed URI path</returns>
         public static string FormatURIPath(string pattern, Dictionary<string, string> pathParameters)
         {


### PR DESCRIPTION
This PR silences the compiler warnings about the comments and removes supressing some of the warnings. One remains because CS1591 would require me to add a comment above all the classes and properties. This pull requests also enables treating warnings as errors to make sure no new warnings about documentation comments can be added in the future.