### PR TITLE
Only do sync over async when necessary.

### DIFF
--- a/Source/LoginRadiusSDK.V2/Http/HttpConnection.cs
+++ b/Source/LoginRadiusSDK.V2/Http/HttpConnection.cs
@@ -225,10 +225,10 @@ namespace LoginRadiusSDK.V2.Http
                                 if (!string.IsNullOrEmpty(payLoad))
                                 {
                                     Stream stream = null;
-#if NetFramework
-                                    stream = httpRequest.GetRequestStream();
-#else
+#if NETSTANDARD1_3
                                     stream = httpRequest.GetRequestStreamAsync().Result;
+#else
+                                    stream = httpRequest.GetRequestStream();
 #endif
                                     using (StreamWriter writerStream = new StreamWriter(stream))
                                     {
@@ -242,7 +242,7 @@ namespace LoginRadiusSDK.V2.Http
                                 break;
                         }
                         WebResponse webResponse = null;
-#if !NetFramework
+#if NETSTANDARD1_3
                         webResponse = httpRequest.GetResponseAsync().Result;
 #else
                         webResponse = httpRequest.GetResponse();


### PR DESCRIPTION
Only for .NET Standard 1.3 it is required to do sync over async. This PR changes the condition that will determine if `.Result` will be done.